### PR TITLE
chmod when new deploy to devapp

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,1 +1,4 @@
+#!/bin/bash
+
+chmod +x /home/kwang/lunchnaste/push.sh
 crontab < cronjobs.txt


### PR DESCRIPTION
#### Motivation:
- morning push broke because i deployed new version yesterday afternoon which resulted in permission issues

#### Changelist:
- need to change permissions to `push.sh` when new copy is deployed

#### Intended Effects:
 - doesn't break morning slack push

#### Proof of Testing:

```
kwang@dev-kwang:~$ tail -n 30 logs/lunchnaste.log
/bin/sh: 1: source: not found
/bin/sh: 1: source: not found
/bin/sh: 1: /bin/sh: 1: source: not found
source: not found
/bin/sh: 1: /home/kwang/lunchnaste/push.sh: Permission denied
/bin/sh: 1: /home/kwang/lunchnaste/push.sh: Permission denied
[2018-08-01 15:49:01] sending Lunch menu to kwang
[2018-08-01 15:49:01] sending Breakfast menu to kwang
You are using pip version 10.0.1, however version 18.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
You are using pip version 10.0.1, however version 18.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
[2018-08-01 15:49:01] success
[2018-08-01 15:49:01] success
kwang@dev-kwang:~$
```